### PR TITLE
Fix link references in celestial bodies index

### DIFF
--- a/Definitions/Celestial Bodies & Calculation Points/Celestial Bodies and Calculated Points Index.md
+++ b/Definitions/Celestial Bodies & Calculation Points/Celestial Bodies and Calculated Points Index.md
@@ -13,7 +13,7 @@ I. Celestial Bodies and Calculation Points
 	    9. ♆ Neptune
 	    10. ♇ Pluto
 	2. Dwarf Planets & Distant Bodies # Recognized by modern astrologers for thier mythic/archetypal impact #
-		1. ⚳ Ceres (see also Astteroids/Ceres)
+                1. ⚳ Ceres (see also Asteroids (Primary Asteroids and Additionals)/Ceres)
 		2. ⚴ Eris
 		3. ⚶ Haumea
 		4. ⚵ Makemake
@@ -24,7 +24,7 @@ I. Celestial Bodies and Calculation Points
 		9. ? Orcus
 		10. ? Varuna
 	3. Asteroids (Primary Asteroids & Additionals)
-		1. Ceres (also classified as a dwarf planet)(see also Dwarf Planets & Distant bodies/Ceres)
+                1. Ceres (also classified as a dwarf planet)(see also Dwarf Planets & Distant Bodies/Ceres)
 		2. Pallas (Pallas Athena)
 		3. Juno
 		4. Vesta
@@ -75,7 +75,7 @@ I. Celestial Bodies and Calculation Points
 		9. 🜕 Poseidon (Uranian astrology)
 		10. 🜖 Cupido (Uranian astrology)
 	7. [[Centaurs]] & Deep Space Bodies
-		1. Chiron (again listed here for classification)(see also Asteroids/Chiron)
+                1. Chiron (again listed here for classification)(see also Asteroids (Primary Asteroids and Additionals)/Chiron)
 		2. Pholus
 		3. Nessus
 		4. Asbolus


### PR DESCRIPTION
## Summary
- fix the Ceres internal link reference
- correct capitalization for Distant Bodies link
- update Chiron link reference to new path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610d8990bc832f9d34525d5d7834b9