### PR TITLE
Implement client-side RAG responses for assistant

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,8 +1,10 @@
+import { formatDisplayPath, resolveDocumentPath } from './path-utils.js';
+
 const DOCUMENTS = [
   {
     id: 'readme',
     title: 'Project README',
-    path: '../README.md',
+    path: 'README.md',
     category: 'Overview',
     description: 'Project overview, philosophy, and quick context for Astrology Arith(m)etic.',
     type: 'markdown'
@@ -10,7 +12,7 @@ const DOCUMENTS = [
   {
     id: 'index-master',
     title: 'Master Index',
-    path: '../INDEX.md',
+    path: 'INDEX.md',
     category: 'Overview',
     description: 'Primary index that maps the larger Astrology Arith(m)etic corpus.',
     type: 'markdown'
@@ -18,7 +20,7 @@ const DOCUMENTS = [
   {
     id: 'intent',
     title: 'Intent of Astrology Arith(m)etic',
-    path: '../00. Intent of Astrology Arith(m)etic.md',
+    path: '00. Intent of Astrology Arith(m)etic.md',
     category: 'Foundations',
     description: 'Opening treatise explaining the aim, covenant, and scope of the work.',
     type: 'markdown'
@@ -26,7 +28,7 @@ const DOCUMENTS = [
   {
     id: 'building-blocks',
     title: 'Building Blocks Manuscript',
-    path: '../Astrology Arith(m)etic - The Building Blocks of Astrology.md',
+    path: 'Astrology Arith(m)etic - The Building Blocks of Astrology.md',
     category: 'Foundations',
     description: 'Detailed manuscript describing the mathematical and esoteric building blocks.',
     type: 'markdown'
@@ -34,7 +36,7 @@ const DOCUMENTS = [
   {
     id: 'vault-index',
     title: 'Vault Index',
-    path: '../Astrology Arithetic Vault - The Building Blocks of Astrology - Index.md',
+    path: 'Astrology Arithetic Vault - The Building Blocks of Astrology - Index.md',
     category: 'Foundations',
     description: 'Index for the Building Blocks vault, mapping ritual components and formulas.',
     type: 'markdown'
@@ -42,7 +44,7 @@ const DOCUMENTS = [
   {
     id: 'astro-arith-index',
     title: 'Astro Arith Index (Legacy HTML)',
-    path: '../Astro-Arith-Index.html',
+    path: 'Astro-Arith-Index.html',
     category: 'Legacy HTML',
     description: 'Historic HTML index included with the repository.',
     type: 'html'
@@ -50,23 +52,15 @@ const DOCUMENTS = [
   {
     id: 'landing',
     title: 'Landing Page Manuscript',
-    path: '../Astrology Arith(m)etic Landing.html',
+    path: 'Astrology Arith(m)etic Landing.html',
     category: 'Legacy HTML',
     description: 'Legacy landing page describing project entry points.',
     type: 'html'
   },
   {
-    id: 'landing-working',
-    title: 'Landing Page (Working Draft)',
-    path: '../Astrology Arith-m-etic Landing (Working).html',
-    category: 'Legacy HTML',
-    description: 'Working draft of the landing page.',
-    type: 'html'
-  },
-  {
     id: 'index-html',
     title: 'Legacy index.html',
-    path: '../index.html',
+    path: 'index.html',
     category: 'Legacy HTML',
     description: 'Original index HTML file included in the repository.',
     type: 'html'
@@ -74,7 +68,7 @@ const DOCUMENTS = [
   {
     id: 'notable-progressions',
     title: 'Notable Astrology Arithetic Progressions',
-    path: '../Notable Astrology Arithetic Progressions.md',
+    path: 'Notable Astrology Arithetic Progressions.md',
     category: 'Progressions',
     description: 'Catalog of notable progressions, rituals, and esoteric advancements.',
     type: 'markdown'
@@ -82,7 +76,7 @@ const DOCUMENTS = [
   {
     id: 'codex-dedication',
     title: 'Codex Dedication Bindrune',
-    path: '../Codex Dedication Bindrune.md',
+    path: 'Codex Dedication Bindrune.md',
     category: 'Rituals & Invocations',
     description: 'Dedication bindrune aligning the practitioner with the codex.',
     type: 'markdown'
@@ -90,7 +84,7 @@ const DOCUMENTS = [
   {
     id: 'codex-activation',
     title: 'Codex Activation Invocation',
-    path: '../Codex Activation Invocation.md',
+    path: 'Codex Activation Invocation.md',
     category: 'Rituals & Invocations',
     description: 'Invocation script for activating the codex and aligning intent.',
     type: 'markdown'
@@ -98,7 +92,7 @@ const DOCUMENTS = [
   {
     id: 'analysis-guidelines',
     title: 'Analysis Guidelines',
-    path: '../Analysis Guidelines/INDEX.md',
+    path: 'Analysis Guidelines/INDEX.md',
     category: 'Guides',
     description: 'Guidelines that inform analysis practices for Astrology Arith(m)etic.',
     type: 'markdown'
@@ -106,7 +100,7 @@ const DOCUMENTS = [
   {
     id: 'interpretation',
     title: 'Interpretation Index',
-    path: '../Interpretation/INDEX.md',
+    path: 'Interpretation/INDEX.md',
     category: 'Interpretation',
     description: 'Index describing interpretative frameworks and reading structures.',
     type: 'markdown'
@@ -114,7 +108,7 @@ const DOCUMENTS = [
   {
     id: 'complete-astrology-readme',
     title: 'Complete Astrology README',
-    path: '../Complete Astrology/README.md',
+    path: 'Complete Astrology/README.md',
     category: 'Complete Astrology',
     description: 'Readme outlining the Complete Astrology materials in the repository.',
     type: 'markdown'
@@ -122,7 +116,7 @@ const DOCUMENTS = [
   {
     id: 'complete-astrology-index',
     title: 'Complete Astrology Index',
-    path: '../Complete Astrology/INDEX.md',
+    path: 'Complete Astrology/INDEX.md',
     category: 'Complete Astrology',
     description: 'Index summarizing the Complete Astrology module.',
     type: 'markdown'
@@ -130,7 +124,7 @@ const DOCUMENTS = [
   {
     id: 'legal-license',
     title: 'Legal License',
-    path: '../Legal/LICENSE.md.md',
+    path: 'Legal/LICENSE.md.md',
     category: 'Legal',
     description: 'Legal license establishing usage rights and obligations.',
     type: 'markdown'
@@ -138,7 +132,7 @@ const DOCUMENTS = [
   {
     id: 'legal-index',
     title: 'Legal Index',
-    path: '../Legal/INDEX.md',
+    path: 'Legal/INDEX.md',
     category: 'Legal',
     description: 'Index for the legal framework surrounding Astrology Arith(m)etic.',
     type: 'markdown'
@@ -178,15 +172,18 @@ async function preloadDocuments() {
   state.searchIndex = [];
   state.chunkIndex = [];
   const loadPromises = DOCUMENTS.map(async (doc) => {
-    const response = await fetch(doc.path);
+    const resolvedPath = resolveDocumentPath(doc.path);
+    const response = await fetch(resolvedPath);
     if (!response.ok) {
-      throw new Error(`Failed to fetch ${doc.path}`);
+      throw new Error(`Failed to fetch ${resolvedPath}`);
     }
     const raw = await response.text();
     const html = convertToHtml(doc, raw);
     const text = extractPlainText(html);
     const entry = {
       ...doc,
+      resolvedPath,
+      displayPath: formatDisplayPath(doc.path),
       raw,
       html,
       text,
@@ -400,7 +397,8 @@ function displayDocument(docId) {
   const loading = document.getElementById('content-loading');
 
   title.textContent = record.title;
-  meta.textContent = `${record.category} • Source file: ${record.path.replace(/^\.\.\//, '')}`;
+  const sourcePath = record.displayPath || record.path;
+  meta.textContent = `${record.category} • Source file: ${sourcePath}`;
   body.innerHTML = record.html;
 
   loading.hidden = true;

--- a/assets/app.js
+++ b/assets/app.js
@@ -148,6 +148,7 @@ const DOCUMENTS = [
 const state = {
   cache: new Map(),
   searchIndex: [],
+  chunkIndex: [],
   currentId: null
 };
 
@@ -174,6 +175,8 @@ async function bootstrapApplication() {
 }
 
 async function preloadDocuments() {
+  state.searchIndex = [];
+  state.chunkIndex = [];
   const loadPromises = DOCUMENTS.map(async (doc) => {
     const response = await fetch(doc.path);
     if (!response.ok) {
@@ -191,6 +194,8 @@ async function preloadDocuments() {
     };
     state.cache.set(doc.id, entry);
     state.searchIndex.push(entry);
+    const chunks = chunkDocument(entry);
+    chunks.forEach((chunk) => state.chunkIndex.push(chunk));
   });
 
   await Promise.all(loadPromises);
@@ -228,6 +233,94 @@ function escapeHtml(input) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+function chunkDocument(entry, maxWords = 140, overlap = 30) {
+  const temp = document.createElement('div');
+  temp.innerHTML = entry.html;
+  const nodes = temp.querySelectorAll('h1, h2, h3, h4, h5, h6, p, li, blockquote');
+  const segments = [];
+  let currentHeading = entry.title;
+
+  nodes.forEach((node) => {
+    const tag = node.tagName.toLowerCase();
+    if (tag.startsWith('h')) {
+      const headingText = node.textContent?.replace(/\s+/g, ' ').trim();
+      if (headingText) {
+        currentHeading = headingText;
+      }
+      return;
+    }
+
+    const text = node.textContent?.replace(/\s+/g, ' ').trim();
+    if (!text) return;
+    segments.push({ heading: currentHeading, text });
+  });
+
+  const chunks = [];
+  let buffer = [];
+  let bufferWordCount = 0;
+  let chunkIndex = 0;
+
+  const pushChunk = () => {
+    if (!bufferWordCount) return;
+    const chunkText = buffer.map((part) => part.text).join(' ').trim();
+    if (!chunkText) {
+      buffer = [];
+      bufferWordCount = 0;
+      return;
+    }
+
+    const firstHeading = buffer.find((part) => part.heading)?.heading || entry.title;
+    const chunkHeading = firstHeading === entry.title ? entry.title : `${entry.title} – ${firstHeading}`;
+    const text = chunkText;
+
+    chunks.push({
+      id: `${entry.id}::${chunkIndex++}`,
+      docId: entry.id,
+      title: entry.title,
+      heading: chunkHeading,
+      text,
+      tokens: tokenize(text)
+    });
+
+    if (overlap > 0) {
+      const words = text.split(/\s+/);
+      const overlapWords = words.slice(-overlap);
+      buffer = overlapWords.length
+        ? [{ heading: firstHeading, text: overlapWords.join(' ') }]
+        : [];
+      bufferWordCount = overlapWords.length;
+    } else {
+      buffer = [];
+      bufferWordCount = 0;
+    }
+  };
+
+  segments.forEach((segment) => {
+    const words = segment.text.split(/\s+/).filter(Boolean);
+    let pointer = 0;
+    while (pointer < words.length) {
+      const remaining = maxWords - bufferWordCount;
+      const take = Math.min(remaining, words.length - pointer);
+      const slice = words.slice(pointer, pointer + take).join(' ');
+      if (slice) {
+        buffer.push({ heading: segment.heading, text: slice });
+        bufferWordCount += take;
+      }
+      pointer += take;
+
+      if (bufferWordCount >= maxWords) {
+        pushChunk();
+      }
+    }
+  });
+
+  if (bufferWordCount) {
+    pushChunk();
+  }
+
+  return chunks;
 }
 
 function renderDocumentList() {
@@ -473,10 +566,9 @@ function setupAssistant() {
     chat.appendChild(bubble);
     chat.scrollTop = chat.scrollHeight;
   };
-
   const respond = (question) => {
-    const matches = rankDocuments(question, 3);
-    if (!matches.length) {
+    const answer = buildAssistantAnswer(question);
+    if (!answer) {
       addMessage(
         'assistant',
         `<strong>Assistant</strong><p>I could not find anything matching that question. Try rephrasing or referencing a specific ritual, index, or term.</p>`
@@ -484,17 +576,7 @@ function setupAssistant() {
       return;
     }
 
-    const answers = matches
-      .map((match) => {
-        const link = `<button type="button" class="source" data-doc-id="${match.id}">Open document →</button>`;
-        return `<p><strong>${match.title}</strong><br>${highlightSnippet(match.snippet, match.tokens)}</p>${link}`;
-      })
-      .join('');
-
-    addMessage(
-      'assistant',
-      `<strong>Assistant</strong>${answers}<p class="assistant-note">These excerpts are drawn directly from the repository. Open a document to read it in full.</p>`
-    );
+    addMessage('assistant', answer);
   };
 
   chat.addEventListener('click', (event) => {
@@ -514,6 +596,134 @@ function setupAssistant() {
 
   addMessage(
     'assistant',
-    `<strong>Assistant</strong><p>Welcome! Ask me about any manuscript, ritual, or legal framework. I will search the collection and provide direct excerpts.</p>`
+    `<strong>Assistant</strong><p>Welcome! Ask me about any manuscript, ritual, or legal framework. I will search the collection, pull the most relevant passages, and synthesize an answer with citations.</p>`
   );
+}
+
+function buildAssistantAnswer(question) {
+  const tokens = tokenize(question);
+  if (!tokens.length) return null;
+
+  const matches = rankChunks(question, 4);
+  if (!matches.length) return null;
+
+  const summary = synthesizeAnswer(tokens, matches);
+  const sources = matches.map((match) => {
+    const snippet = buildContextualSnippet(match.text, tokens);
+    return {
+      id: match.docId,
+      title: match.title,
+      heading: match.heading,
+      snippet,
+      tokens
+    };
+  });
+
+  const sourcesHtml = sources
+    .map((source) => {
+      const displayTitle = source.heading && source.heading !== source.title ? source.heading : source.title;
+      const snippetHtml = highlightSnippet(escapeHtml(source.snippet), source.tokens);
+      return `
+        <div class="assistant-source">
+          <div class="assistant-source-meta">
+            <strong>${escapeHtml(displayTitle)}</strong>
+            <span>${snippetHtml}</span>
+          </div>
+          <button type="button" class="source" data-doc-id="${source.id}">Open document →</button>
+        </div>
+      `;
+    })
+    .join('');
+
+  return `
+    <strong>Assistant</strong>
+    ${summary}
+    <div class="assistant-sources">
+      <p class="assistant-note">Supporting passages:</p>
+      ${sourcesHtml}
+    </div>
+  `;
+}
+
+function rankChunks(query, limit = 4) {
+  const tokens = tokenize(query);
+  if (!tokens.length) return [];
+
+  return state.chunkIndex
+    .map((chunk) => {
+      const baseScore = scoreEntry({ text: chunk.text }, tokens);
+      const heading = chunk.heading?.toLowerCase() || '';
+      const title = chunk.title?.toLowerCase() || '';
+      const headingBoost = tokens.reduce((score, token) => {
+        const lowerToken = token.toLowerCase();
+        if (heading.includes(lowerToken)) score += 3;
+        if (title.includes(lowerToken)) score += 1;
+        return score;
+      }, 0);
+      const totalScore = baseScore + headingBoost;
+      return {
+        ...chunk,
+        score: totalScore
+      };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+function synthesizeAnswer(tokens, matches) {
+  const tokenSet = new Set(tokens.map((token) => token.toLowerCase()));
+  const insights = matches.map((match) => {
+    const sentences = extractSupportingSentences(match.text, tokenSet, 2);
+    const sentenceHtml = highlightSnippet(escapeHtml(sentences.join(' ')), tokens);
+    const displayHeading = match.heading && match.heading !== match.title ? match.heading : match.title;
+    return `<li><strong>${escapeHtml(displayHeading)}</strong> — ${sentenceHtml}</li>`;
+  });
+
+  if (!insights.length) {
+    const fallback = matches
+      .map((match) => `<li><strong>${escapeHtml(match.title)}</strong> — ${highlightSnippet(escapeHtml(buildContextualSnippet(match.text, tokens)), tokens)}</li>`)
+      .join('');
+    return `
+      <div class="assistant-summary">
+        <p>Here is what I gathered from the repository:</p>
+        <ul>${fallback}</ul>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="assistant-summary">
+      <p>Here is what I gathered from the repository:</p>
+      <ul>
+        ${insights.join('')}
+      </ul>
+    </div>
+  `;
+}
+
+function extractSupportingSentences(text, tokenSet, limit = 2) {
+  const sentences = text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+
+  if (!sentences.length) {
+    return [text];
+  }
+
+  const ranked = sentences
+    .map((sentence) => {
+      const lower = sentence.toLowerCase();
+      const score = Array.from(tokenSet).reduce((acc, token) => (lower.includes(token) ? acc + 1 : acc), 0);
+      return { sentence, score };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const topSentences = ranked.filter((item) => item.score > 0).slice(0, limit);
+  if (topSentences.length) {
+    return topSentences.map((item) => item.sentence);
+  }
+
+  return sentences.slice(0, limit);
 }

--- a/assets/path-utils.js
+++ b/assets/path-utils.js
@@ -1,0 +1,66 @@
+const DEFAULT_ORIGIN = typeof window !== 'undefined' && window.location?.origin
+  ? window.location.origin
+  : 'http://localhost';
+
+function ensureTrailingSlash(path) {
+  if (!path) return '/';
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+export function getBasePath(pathname = undefined) {
+  const sourcePath =
+    pathname !== undefined
+      ? pathname
+      : typeof window !== 'undefined' && window.location?.pathname
+        ? window.location.pathname
+        : '/';
+  if (!sourcePath) return '/';
+  if (sourcePath.endsWith('/')) return sourcePath;
+  return sourcePath.replace(/[^/]*$/, '');
+}
+
+export function normalizeDocumentPath(path) {
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path)) return path;
+  if (path.startsWith('/')) return path.replace(/^\/+/, '');
+
+  let working = path.trim();
+  while (working.startsWith('./')) {
+    working = working.slice(2);
+  }
+  while (working.startsWith('../')) {
+    working = working.slice(3);
+  }
+  return working;
+}
+
+export function resolveDocumentPath(path, options = {}) {
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path)) return path;
+
+  const normalized = normalizeDocumentPath(path);
+  const origin = options.origin || DEFAULT_ORIGIN;
+  const basePath = ensureTrailingSlash(
+    options.basePath !== undefined
+      ? options.basePath
+      : getBasePath(options.pathname)
+  );
+  const baseUrl = new URL(basePath, origin);
+  const url = new URL(normalized, baseUrl);
+  return url.pathname;
+}
+
+export function formatDisplayPath(path) {
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path)) return path;
+  const normalized = normalizeDocumentPath(path);
+  return decodeURIComponent(normalized);
+}
+
+export function encodeForFetch(path) {
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path)) return path;
+  const normalized = normalizeDocumentPath(path);
+  const parts = normalized.split('/').map((segment) => encodeURIComponent(segment));
+  return parts.join('/');
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -316,6 +316,57 @@ body.dark {
   color: var(--text-light);
 }
 
+.assistant-summary {
+  background: rgba(91, 75, 138, 0.08);
+  border: 1px solid rgba(91, 75, 138, 0.15);
+  border-radius: calc(var(--radius) - 4px);
+  padding: 0.85rem 1rem;
+}
+
+.assistant-summary ul {
+  margin: 0.65rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.assistant-summary li {
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.assistant-summary li:last-child {
+  margin-bottom: 0;
+}
+
+.assistant-sources {
+  margin-top: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.assistant-source {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: calc(var(--radius) - 4px);
+  border: 1px solid rgba(91, 75, 138, 0.15);
+  background: rgba(91, 75, 138, 0.05);
+}
+
+.assistant-source-meta strong {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.assistant-source-meta span {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--text-light);
+}
+
 .assistant-form {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Astrology Arith(m)etic Knowledge Base</title>
   <link rel="stylesheet" href="assets/styles.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
-  <script src="assets/app.js" defer></script>
+  <script type="module" src="assets/app.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/tests/gh-pages-paths.test.mjs
+++ b/tests/gh-pages-paths.test.mjs
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { formatDisplayPath, resolveDocumentPath } from '../assets/path-utils.js';
+
+describe('resolveDocumentPath', () => {
+  it('resolves paths at the site root', () => {
+    const result = resolveDocumentPath('README.md', { origin: 'https://example.com', basePath: '/' });
+    assert.equal(result, '/README.md');
+  });
+
+  it('resolves paths for GitHub Pages project sites', () => {
+    const result = resolveDocumentPath('README.md', {
+      origin: 'https://example.com',
+      basePath: '/Astrology-Arith-m-etic/'
+    });
+    assert.equal(result, '/Astrology-Arith-m-etic/README.md');
+  });
+
+  it('encodes nested paths that contain spaces', () => {
+    const result = resolveDocumentPath('Analysis Guidelines/INDEX.md', {
+      origin: 'https://example.com',
+      basePath: '/Astrology-Arith-m-etic/'
+    });
+    assert.equal(result, '/Astrology-Arith-m-etic/Analysis%20Guidelines/INDEX.md');
+  });
+
+  it('strips parent directory prefixes', () => {
+    const result = resolveDocumentPath('../Legal/LICENSE.md.md', {
+      origin: 'https://example.com',
+      basePath: '/Astrology-Arith-m-etic/'
+    });
+    assert.equal(result, '/Astrology-Arith-m-etic/Legal/LICENSE.md.md');
+  });
+});
+
+describe('formatDisplayPath', () => {
+  it('presents a human readable path without encoding', () => {
+    const result = formatDisplayPath('Analysis Guidelines/INDEX.md');
+    assert.equal(result, 'Analysis Guidelines/INDEX.md');
+  });
+});


### PR DESCRIPTION
## Summary
- chunk documents during preload to build a retrieval index for the assistant
- synthesize answers from the highest scoring passages and surface supporting sources in chat
- style the assistant summary and source list for clearer, citation-focused replies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690b188f4728832fbf69019896ed4418