### PR TITLE
Fix GitHub Pages asset loading for www index

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Astrology Arith(m)etic Knowledge Base</title>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="../assets/styles.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
-  <script src="assets/app.js" defer></script>
+  <script type="module" src="../assets/app.js"></script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
## Summary
- update the www build to load shared assets from the repository root
- ensure the www index loads the module-based application script so navigation works

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_690b1f076304832fb8385f08947eca3a