### PR TITLE
Ensure layout fits viewport with scroll support

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -17,6 +17,11 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   background: var(--bg);
@@ -24,6 +29,8 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 body.dark {
@@ -114,6 +121,10 @@ body.dark {
   gap: 1.75rem;
   padding: clamp(1.5rem, 3vw, 2.5rem);
   flex: 1;
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: auto;
+  min-height: 0;
 }
 
 .sidebar,
@@ -126,6 +137,7 @@ body.dark {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .sidebar-header h2 {


### PR DESCRIPTION
## Summary
- ensure the base document spans the viewport so the window can provide scrollbars
- constrain the main layout to the viewport width while allowing horizontal scrolling when necessary
- allow primary panels to respect the grid height to avoid overflow clipping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b66022f80832f9c00088b2a45a0f8